### PR TITLE
Support live window resizing

### DIFF
--- a/AKPlugin.swift
+++ b/AKPlugin.swift
@@ -15,37 +15,122 @@ private struct AKAppSettingsData: Codable {
 }
 
 class AKPlugin: NSObject, Plugin {
+    private static let appSettingsURL: URL = {
+        let bundleIdentifier = Bundle.main.bundleIdentifier ?? ""
+        return URL(fileURLWithPath: "/Users/\(NSUserName())/Library/Containers/io.playcover.PlayCover")
+            .appendingPathComponent("App Settings")
+            .appendingPathComponent("\(bundleIdentifier).plist")
+    }()
+
+    private let trackedWindows = NSHashTable<NSWindow>.weakObjects()
+
     required override init() {
         super.init()
-        if hideTitleBarSetting == false {
-                return
-        }
+        guard hideTitleBarSetting else { return }
+
         if let window = NSApplication.shared.windows.first {
-            // Enable all window management features
-            window.styleMask.insert([.resizable, .fullSizeContentView])
-            window.collectionBehavior = [.fullScreenPrimary, .managed, .participatesInCycle]
-
-            // Enable automatic window management
-            window.isMovable = true
-            window.isMovableByWindowBackground = true
-            window.titlebarAppearsTransparent = true
-            window.titleVisibility = .hidden
-            window.toolbar = nil
-            window.title = ""
-            NSWindow.allowsAutomaticWindowTabbing = true
+            configureWindow(window)
         }
 
-        // Apply the same appearance rules to any subsequent windows that may be created
         NotificationCenter.default.addObserver(
             forName: NSWindow.didBecomeKeyNotification,
             object: nil,
-            queue: .main) { notif in
-            guard let win = notif.object as? NSWindow else { return }
-            win.styleMask.insert([.resizable, .fullSizeContentView])
-            win.titlebarAppearsTransparent = true
-            win.titleVisibility = .hidden
-            win.toolbar = nil
-            win.title = ""
+            queue: .main) { [weak self] notif in
+            guard let self, let win = notif.object as? NSWindow else { return }
+            self.configureWindow(win)
+        }
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleWindowDidResize(_:)),
+            name: NSWindow.didResizeNotification,
+            object: nil)
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleWindowResizeDidEnd(_:)),
+            name: NSWindow.didEndLiveResizeNotification,
+            object: nil)
+    }
+
+    private func configureWindow(_ window: NSWindow) {
+        window.styleMask.insert([.resizable, .fullSizeContentView])
+        window.collectionBehavior = [.fullScreenPrimary, .managed, .participatesInCycle]
+
+        window.isMovable = true
+        window.isMovableByWindowBackground = true
+        window.titlebarAppearsTransparent = true
+        window.titleVisibility = .hidden
+        window.toolbar = nil
+        window.title = ""
+        NSWindow.allowsAutomaticWindowTabbing = true
+
+        trackedWindows.add(window)
+    }
+
+    @objc private func handleWindowDidResize(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow else { return }
+        guard shouldObserve(window: window) else { return }
+
+        if !window.inLiveResize {
+            persistWindowSize(for: window)
+        }
+    }
+
+    @objc private func handleWindowResizeDidEnd(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow else { return }
+        guard shouldObserve(window: window) else { return }
+
+        persistWindowSize(for: window)
+    }
+
+    private func shouldObserve(window: NSWindow) -> Bool {
+        guard hideTitleBarSetting else { return false }
+        return trackedWindows.allObjects.contains { $0 === window }
+    }
+
+    private func persistWindowSize(for window: NSWindow) {
+        let frame = window.frame
+        guard frame.width > 0, frame.height > 0 else { return }
+
+        let width = Int(frame.width.rounded())
+        let height = Int(frame.height.rounded())
+
+        var format = PropertyListSerialization.PropertyListFormat.binary
+        let existingData = try? Data(contentsOf: Self.appSettingsURL)
+        var plist: [String: Any] = [:]
+        if let data = existingData,
+           let decoded = try? PropertyListSerialization.propertyList(from: data,
+                                                                    options: [],
+                                                                    format: &format) as? [String: Any] {
+            plist = decoded
+        }
+
+        var changed = existingData == nil
+        if (plist["windowWidth"] as? NSNumber)?.intValue != width {
+            plist["windowWidth"] = width
+            changed = true
+        }
+        if (plist["windowHeight"] as? NSNumber)?.intValue != height {
+            plist["windowHeight"] = height
+            changed = true
+        }
+
+        guard changed else { return }
+
+        guard let updatedData = try? PropertyListSerialization.data(fromPropertyList: plist,
+                                                                    format: format,
+                                                                    options: 0) else {
+            return
+        }
+
+        let directoryURL = Self.appSettingsURL.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+
+        do {
+            try updatedData.write(to: Self.appSettingsURL, options: .atomic)
+        } catch {
+            NSLog("PC-DEBUG: Failed to persist window size: %@", error.localizedDescription)
         }
     }
 
@@ -268,11 +353,7 @@ class AKPlugin: NSObject, Plugin {
     private var hideTitleBarSetting: Bool { Self.hideTitleBarPreference }
 
     fileprivate static var hideTitleBarPreference: Bool = {
-        let bundleIdentifier = Bundle.main.bundleIdentifier ?? ""
-        let settingsURL = URL(fileURLWithPath: "/Users/\(NSUserName())/Library/Containers/io.playcover.PlayCover")
-            .appendingPathComponent("App Settings")
-            .appendingPathComponent("\(bundleIdentifier).plist")
-        guard let data = try? Data(contentsOf: settingsURL),
+        guard let data = try? Data(contentsOf: appSettingsURL),
               let decoded = try? PropertyListDecoder().decode(AKAppSettingsData.self, from: data) else {
             return false
         }

--- a/PlayTools/PlayScreen.swift
+++ b/PlayTools/PlayScreen.swift
@@ -6,10 +6,49 @@ import Foundation
 import UIKit
 
 let screen = PlayScreen.shared
-let isInvertFixEnabled = PlaySettings.shared.inverseScreenValues && PlaySettings.shared.adaptiveDisplay
-let mainScreenWidth =  !isInvertFixEnabled ? PlaySettings.shared.windowSizeWidth : PlaySettings.shared.windowSizeHeight
-let mainScreenHeight = !isInvertFixEnabled ? PlaySettings.shared.windowSizeHeight : PlaySettings.shared.windowSizeWidth
-let customScaler = PlaySettings.shared.customScaler
+
+fileprivate var isInvertFixEnabled: Bool {
+    let settings = PlaySettings.shared
+    return settings.inverseScreenValues && settings.adaptiveDisplay
+}
+
+fileprivate var customScaler: Double {
+    PlaySettings.shared.customScaler
+}
+
+private var currentWindowFrame: CGRect? {
+    guard let frame = AKInterface.shared?.windowFrame, frame.width > 0, frame.height > 0 else {
+        return nil
+    }
+    return frame
+}
+
+fileprivate var mainScreenSize: CGSize {
+    let settings = PlaySettings.shared
+
+    if let frame = currentWindowFrame {
+        let width = frame.width
+        let height = frame.height
+        settings.cacheWindowSize(width: width, height: height)
+
+        if isInvertFixEnabled {
+            return CGSize(width: height, height: width)
+        } else {
+            return CGSize(width: width, height: height)
+        }
+    }
+
+    let storedWidth = settings.windowSizeWidth
+    let storedHeight = settings.windowSizeHeight
+    if isInvertFixEnabled {
+        return CGSize(width: storedHeight, height: storedWidth)
+    } else {
+        return CGSize(width: storedWidth, height: storedHeight)
+    }
+}
+
+fileprivate var mainScreenWidth: CGFloat { mainScreenSize.width }
+fileprivate var mainScreenHeight: CGFloat { mainScreenSize.height }
 
 extension CGSize {
     func aspectRatio() -> CGFloat {

--- a/PlayTools/PlaySettings.swift
+++ b/PlayTools/PlaySettings.swift
@@ -33,9 +33,15 @@ let settings = PlaySettings.shared
 
     @objc lazy var bypass = settingsData.bypass
 
-    @objc lazy var windowSizeHeight = CGFloat(settingsData.windowHeight)
+    @objc dynamic var windowSizeHeight: CGFloat {
+        get { CGFloat(settingsData.windowHeight) }
+        set { updateWindowSize(width: nil, height: newValue, persist: false) }
+    }
 
-    @objc lazy var windowSizeWidth = CGFloat(settingsData.windowWidth)
+    @objc dynamic var windowSizeWidth: CGFloat {
+        get { CGFloat(settingsData.windowWidth) }
+        set { updateWindowSize(width: newValue, height: nil, persist: false) }
+    }
 
     @objc lazy var inverseScreenValues = settingsData.inverseScreenValues
 
@@ -85,6 +91,55 @@ let settings = PlaySettings.shared
     @objc lazy var hideTitleBar = settingsData.hideTitleBar
 
     @objc lazy var checkMicPermissionSync = settingsData.checkMicPermissionSync
+
+    @objc func cacheWindowSize(width: CGFloat, height: CGFloat) {
+        updateWindowSize(width: width, height: height, persist: false)
+    }
+
+    @objc func persistWindowSize(width: CGFloat, height: CGFloat) {
+        updateWindowSize(width: width, height: height, persist: true)
+    }
+
+    private func updateWindowSize(width: CGFloat?, height: CGFloat?, persist: Bool) {
+        var didChange = false
+
+        if let width { didChange = updateWidth(width) || didChange }
+        if let height { didChange = updateHeight(height) || didChange }
+
+        if persist, didChange {
+            persistSettings()
+        }
+    }
+
+    private func updateWidth(_ value: CGFloat) -> Bool {
+        let normalized = normalizedDimension(from: value)
+        guard settingsData.windowWidth != normalized else { return false }
+        settingsData.windowWidth = normalized
+        return true
+    }
+
+    private func updateHeight(_ value: CGFloat) -> Bool {
+        let normalized = normalizedDimension(from: value)
+        guard settingsData.windowHeight != normalized else { return false }
+        settingsData.windowHeight = normalized
+        return true
+    }
+
+    private func normalizedDimension(from value: CGFloat) -> Int {
+        let clamped = max(value, 1)
+        return Int(clamped.rounded())
+    }
+
+    private func persistSettings() {
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .binary
+        do {
+            let data = try encoder.encode(settingsData)
+            try data.write(to: settingsUrl, options: .atomic)
+        } catch {
+            print("[PlayTools] Failed to persist PlaySettings: \(error)")
+        }
+    }
 }
 
 struct AppSettingsData: Codable {


### PR DESCRIPTION
## Summary
- read the active NSWindow frame when computing PlayScreen aspect ratios so swizzled dimensions follow manual window drags
- expose dynamic window size accessors on PlaySettings and add helpers to cache or persist updated dimensions
- watch resize notifications in the macOS plugin so configured windows remain resizable and their frame sizes are written back to the PlayCover settings plist

## Testing
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ca072021d08323a7986ffbb8de5f89