### PR TITLE
Track live window resizes from the macOS plugin

### DIFF
--- a/AKPlugin.swift
+++ b/AKPlugin.swift
@@ -14,38 +14,135 @@ private struct AKAppSettingsData: Codable {
     var hideTitleBar: Bool?
 }
 
+private struct WindowSize: Equatable {
+    let width: Int
+    let height: Int
+
+    init(width: Int, height: Int) {
+        self.width = width
+        self.height = height
+    }
+
+    init?(frame: CGRect) {
+        guard frame.width > 0, frame.height > 0 else { return nil }
+        let normalizedWidth = Int(max(frame.width, 1).rounded())
+        let normalizedHeight = Int(max(frame.height, 1).rounded())
+        self.init(width: normalizedWidth, height: normalizedHeight)
+    }
+
+    init?(dictionary: [String: Any]) {
+        guard let widthValue = WindowSize.extractIntValue(forKey: "windowWidth", from: dictionary),
+              let heightValue = WindowSize.extractIntValue(forKey: "windowHeight", from: dictionary) else {
+            return nil
+        }
+        self.init(width: widthValue, height: heightValue)
+    }
+
+    private static func extractIntValue(forKey key: String, from dictionary: [String: Any]) -> Int? {
+        if let number = dictionary[key] as? NSNumber {
+            return number.intValue
+        }
+        if let stringValue = dictionary[key] as? String, let intValue = Int(stringValue) {
+            return intValue
+        }
+        return dictionary[key] as? Int
+    }
+}
+
 class AKPlugin: NSObject, Plugin {
+    private static let appSettingsURL: URL = {
+        let bundleIdentifier = Bundle.main.bundleIdentifier ?? ""
+        return URL(fileURLWithPath: "/Users/\(NSUserName())/Library/Containers/io.playcover.PlayCover")
+            .appendingPathComponent("App Settings")
+            .appendingPathComponent("\(bundleIdentifier).plist")
+    }()
+
+    private static var cachedWindowSize: WindowSize? = {
+        guard let dictionary = loadAppSettingsDictionary() else { return nil }
+        return WindowSize(dictionary: dictionary)
+    }()
+
+    private static func loadAppSettingsDictionary() -> [String: Any]? {
+        guard let data = try? Data(contentsOf: appSettingsURL) else { return nil }
+        return (try? PropertyListSerialization.propertyList(from: data, options: [], format: nil)) as? [String: Any]
+    }
+
+    @discardableResult
+    private static func persistAppSettingsDictionary(_ dictionary: [String: Any]) -> Bool {
+        do {
+            let data = try PropertyListSerialization.data(fromPropertyList: dictionary, format: .binary, options: 0)
+            try data.write(to: appSettingsURL, options: .atomic)
+            return true
+        } catch {
+            print("[PlayTools] Failed to persist PlaySettings from plugin: \(error)")
+            return false
+        }
+    }
+
+    private weak var primaryWindow: NSWindow?
+    private var pendingWindowSize: WindowSize?
+    private var resizeDebounceWorkItem: DispatchWorkItem?
+    private var resizeObserver: NSObjectProtocol?
+    private var liveResizeObserver: NSObjectProtocol?
+
     required override init() {
         super.init()
-        if hideTitleBarSetting == false {
-                return
-        }
+        guard hideTitleBarSetting else { return }
+
         if let window = NSApplication.shared.windows.first {
-            // Enable all window management features
-            window.styleMask.insert([.resizable, .fullSizeContentView])
-            window.collectionBehavior = [.fullScreenPrimary, .managed, .participatesInCycle]
-
-            // Enable automatic window management
-            window.isMovable = true
-            window.isMovableByWindowBackground = true
-            window.titlebarAppearsTransparent = true
-            window.titleVisibility = .hidden
-            window.toolbar = nil
-            window.title = ""
-            NSWindow.allowsAutomaticWindowTabbing = true
+            configureWindow(window)
         }
 
-        // Apply the same appearance rules to any subsequent windows that may be created
         NotificationCenter.default.addObserver(
             forName: NSWindow.didBecomeKeyNotification,
             object: nil,
-            queue: .main) { notif in
-            guard let win = notif.object as? NSWindow else { return }
-            win.styleMask.insert([.resizable, .fullSizeContentView])
-            win.titlebarAppearsTransparent = true
-            win.titleVisibility = .hidden
-            win.toolbar = nil
-            win.title = ""
+            queue: .main) { [weak self] notif in
+            guard let self, let win = notif.object as? NSWindow else { return }
+            self.configureWindow(win)
+        }
+
+        resizeObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResizeNotification,
+            object: nil,
+            queue: .main) { [weak self] notif in
+            guard let self, let window = notif.object as? NSWindow else { return }
+            self.handleWindowDidResize(window)
+        }
+
+        liveResizeObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didEndLiveResizeNotification,
+            object: nil,
+            queue: .main) { [weak self] notif in
+            guard let self, let window = notif.object as? NSWindow else { return }
+            self.persistPendingWindowSize(for: window)
+        }
+    }
+
+    deinit {
+        if let observer = resizeObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        if let observer = liveResizeObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        resizeDebounceWorkItem?.cancel()
+        persistPendingWindowSize()
+    }
+
+    private func configureWindow(_ window: NSWindow) {
+        window.styleMask.insert([.resizable, .fullSizeContentView])
+        window.collectionBehavior = [.fullScreenPrimary, .managed, .participatesInCycle]
+
+        window.isMovable = true
+        window.isMovableByWindowBackground = true
+        window.titlebarAppearsTransparent = true
+        window.titleVisibility = .hidden
+        window.toolbar = nil
+        window.title = ""
+        NSWindow.allowsAutomaticWindowTabbing = true
+
+        if shouldTrack(window: window, allowAssignment: true) {
+            updateTrackedWindowSize(using: window, persistImmediately: true)
         }
     }
 
@@ -268,14 +365,76 @@ class AKPlugin: NSObject, Plugin {
     private var hideTitleBarSetting: Bool { Self.hideTitleBarPreference }
 
     fileprivate static var hideTitleBarPreference: Bool = {
-        let bundleIdentifier = Bundle.main.bundleIdentifier ?? ""
-        let settingsURL = URL(fileURLWithPath: "/Users/\(NSUserName())/Library/Containers/io.playcover.PlayCover")
-            .appendingPathComponent("App Settings")
-            .appendingPathComponent("\(bundleIdentifier).plist")
-        guard let data = try? Data(contentsOf: settingsURL),
+        guard let data = try? Data(contentsOf: appSettingsURL),
               let decoded = try? PropertyListDecoder().decode(AKAppSettingsData.self, from: data) else {
             return false
         }
         return decoded.hideTitleBar ?? false
     }()
+
+    private func handleWindowDidResize(_ window: NSWindow) {
+        guard shouldTrack(window: window, allowAssignment: primaryWindow == nil) else { return }
+        scheduleWindowSizePersistence(for: window)
+    }
+
+    private func shouldTrack(window: NSWindow, allowAssignment: Bool) -> Bool {
+        if let tracked = primaryWindow {
+            return tracked === window
+        }
+        if allowAssignment {
+            primaryWindow = window
+            return true
+        }
+        return false
+    }
+
+    private func updateTrackedWindowSize(using window: NSWindow, persistImmediately: Bool) {
+        guard let size = WindowSize(frame: window.frame) else { return }
+        pendingWindowSize = size
+        if persistImmediately {
+            persistPendingWindowSize()
+        } else {
+            scheduleFlushWorkItem()
+        }
+    }
+
+    private func scheduleWindowSizePersistence(for window: NSWindow) {
+        guard let size = WindowSize(frame: window.frame) else { return }
+        pendingWindowSize = size
+        scheduleFlushWorkItem()
+    }
+
+    private func scheduleFlushWorkItem() {
+        resizeDebounceWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.persistPendingWindowSize()
+        }
+        resizeDebounceWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25, execute: workItem)
+    }
+
+    private func persistPendingWindowSize(for window: NSWindow? = nil) {
+        if let window {
+            guard shouldTrack(window: window, allowAssignment: primaryWindow == nil) else { return }
+            if let size = WindowSize(frame: window.frame) {
+                pendingWindowSize = size
+            }
+        }
+
+        guard let size = pendingWindowSize else { return }
+        pendingWindowSize = nil
+        resizeDebounceWorkItem?.cancel()
+        resizeDebounceWorkItem = nil
+
+        if size == Self.cachedWindowSize {
+            return
+        }
+
+        var dictionary = Self.loadAppSettingsDictionary() ?? [:]
+        dictionary["windowWidth"] = size.width
+        dictionary["windowHeight"] = size.height
+        if Self.persistAppSettingsDictionary(dictionary) {
+            Self.cachedWindowSize = size
+        }
+    }
 }

--- a/PlayTools/PlayScreen.swift
+++ b/PlayTools/PlayScreen.swift
@@ -6,10 +6,50 @@ import Foundation
 import UIKit
 
 let screen = PlayScreen.shared
-let isInvertFixEnabled = PlaySettings.shared.inverseScreenValues && PlaySettings.shared.adaptiveDisplay
-let mainScreenWidth =  !isInvertFixEnabled ? PlaySettings.shared.windowSizeWidth : PlaySettings.shared.windowSizeHeight
-let mainScreenHeight = !isInvertFixEnabled ? PlaySettings.shared.windowSizeHeight : PlaySettings.shared.windowSizeWidth
-let customScaler = PlaySettings.shared.customScaler
+
+fileprivate var isInvertFixEnabled: Bool {
+    let settings = PlaySettings.shared
+    return settings.inverseScreenValues && settings.adaptiveDisplay
+}
+
+fileprivate var customScaler: Double {
+    PlaySettings.shared.customScaler
+}
+
+private var currentWindowFrame: CGRect? {
+    guard let frame = AKInterface.shared?.windowFrame, frame.width > 0, frame.height > 0 else {
+        return nil
+    }
+    return frame
+}
+
+fileprivate var mainScreenSize: CGSize {
+    let settings = PlaySettings.shared
+
+    if let frame = currentWindowFrame {
+        let width = frame.width
+        let height = frame.height
+        settings.cacheWindowSize(width: width, height: height)
+        settings.persistWindowSizeIfNeeded()
+
+        if isInvertFixEnabled {
+            return CGSize(width: height, height: width)
+        } else {
+            return CGSize(width: width, height: height)
+        }
+    }
+
+    let storedWidth = settings.windowSizeWidth
+    let storedHeight = settings.windowSizeHeight
+    if isInvertFixEnabled {
+        return CGSize(width: storedHeight, height: storedWidth)
+    } else {
+        return CGSize(width: storedWidth, height: storedHeight)
+    }
+}
+
+fileprivate var mainScreenWidth: CGFloat { mainScreenSize.width }
+fileprivate var mainScreenHeight: CGFloat { mainScreenSize.height }
 
 extension CGSize {
     func aspectRatio() -> CGFloat {

--- a/PlayTools/PlaySettings.swift
+++ b/PlayTools/PlaySettings.swift
@@ -33,9 +33,25 @@ let settings = PlaySettings.shared
 
     @objc lazy var bypass = settingsData.bypass
 
-    @objc lazy var windowSizeHeight = CGFloat(settingsData.windowHeight)
+    private var needsWindowSizePersistence = false
 
-    @objc lazy var windowSizeWidth = CGFloat(settingsData.windowWidth)
+    @objc dynamic var windowSizeHeight: CGFloat {
+        get { CGFloat(settingsData.windowHeight) }
+        set {
+            if updateWindowSize(width: nil, height: newValue) {
+                needsWindowSizePersistence = true
+            }
+        }
+    }
+
+    @objc dynamic var windowSizeWidth: CGFloat {
+        get { CGFloat(settingsData.windowWidth) }
+        set {
+            if updateWindowSize(width: newValue, height: nil) {
+                needsWindowSizePersistence = true
+            }
+        }
+    }
 
     @objc lazy var inverseScreenValues = settingsData.inverseScreenValues
 
@@ -85,6 +101,65 @@ let settings = PlaySettings.shared
     @objc lazy var hideTitleBar = settingsData.hideTitleBar
 
     @objc lazy var checkMicPermissionSync = settingsData.checkMicPermissionSync
+
+    @objc func cacheWindowSize(width: CGFloat, height: CGFloat) {
+        if updateWindowSize(width: width, height: height) {
+            needsWindowSizePersistence = true
+        }
+    }
+
+    @objc func persistWindowSize(width: CGFloat, height: CGFloat) {
+        if updateWindowSize(width: width, height: height) {
+            needsWindowSizePersistence = true
+        }
+        persistWindowSizeIfNeeded()
+    }
+
+    @objc func persistWindowSizeIfNeeded() {
+        guard needsWindowSizePersistence else { return }
+        needsWindowSizePersistence = false
+        persistSettings()
+    }
+
+    @discardableResult
+    private func updateWindowSize(width: CGFloat?, height: CGFloat?) -> Bool {
+        var didChange = false
+
+        if let width { didChange = updateWidth(width) || didChange }
+        if let height { didChange = updateHeight(height) || didChange }
+
+        return didChange
+    }
+
+    private func updateWidth(_ value: CGFloat) -> Bool {
+        let normalized = normalizedDimension(from: value)
+        guard settingsData.windowWidth != normalized else { return false }
+        settingsData.windowWidth = normalized
+        return true
+    }
+
+    private func updateHeight(_ value: CGFloat) -> Bool {
+        let normalized = normalizedDimension(from: value)
+        guard settingsData.windowHeight != normalized else { return false }
+        settingsData.windowHeight = normalized
+        return true
+    }
+
+    private func normalizedDimension(from value: CGFloat) -> Int {
+        let clamped = max(value, 1)
+        return Int(clamped.rounded())
+    }
+
+    private func persistSettings() {
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .binary
+        do {
+            let data = try encoder.encode(settingsData)
+            try data.write(to: settingsUrl, options: .atomic)
+        } catch {
+            print("[PlayTools] Failed to persist PlaySettings: \(error)")
+        }
+    }
 }
 
 struct AppSettingsData: Codable {


### PR DESCRIPTION
## Summary
- track the primary PlayCover window and observe resize notifications so manual drags register on macOS
- debounce and persist the window width and height back into the PlayCover settings plist after resizing to keep the iOS metrics aligned

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca072021d08323a7986ffbb8de5f89