### PR TITLE
Auto-update window size from runtime bounds

### DIFF
--- a/PlayTools/PlayScreen.swift
+++ b/PlayTools/PlayScreen.swift
@@ -6,10 +6,24 @@ import Foundation
 import UIKit
 
 let screen = PlayScreen.shared
-let isInvertFixEnabled = PlaySettings.shared.inverseScreenValues && PlaySettings.shared.adaptiveDisplay
-let mainScreenWidth =  !isInvertFixEnabled ? PlaySettings.shared.windowSizeWidth : PlaySettings.shared.windowSizeHeight
-let mainScreenHeight = !isInvertFixEnabled ? PlaySettings.shared.windowSizeHeight : PlaySettings.shared.windowSizeWidth
-let customScaler = PlaySettings.shared.customScaler
+private var isInvertFixEnabled: Bool {
+    let settings = PlaySettings.shared
+    return settings.inverseScreenValues && settings.adaptiveDisplay
+}
+
+private var mainScreenWidth: CGFloat {
+    let settings = PlaySettings.shared
+    return !isInvertFixEnabled ? settings.windowSizeWidth : settings.windowSizeHeight
+}
+
+private var mainScreenHeight: CGFloat {
+    let settings = PlaySettings.shared
+    return !isInvertFixEnabled ? settings.windowSizeHeight : settings.windowSizeWidth
+}
+
+private var customScaler: Double {
+    PlaySettings.shared.customScaler
+}
 
 extension CGSize {
     func aspectRatio() -> CGFloat {
@@ -90,6 +104,7 @@ public class PlayScreen: NSObject {
     }
 
     @objc public static func bounds(_ rect: CGRect) -> CGRect {
+        updateStoredWindowSize(from: rect, isReversed: false)
         return rect.toAspectRatio()
     }
 
@@ -169,6 +184,7 @@ public class PlayScreen: NSObject {
         return rect.toAspectRatioDefault()
     }
     @objc public static func boundsDefault(_ rect: CGRect) -> CGRect {
+        updateStoredWindowSize(from: rect, isReversed: false)
         return rect.toAspectRatioDefault()
     }
 
@@ -183,6 +199,15 @@ public class PlayScreen: NSObject {
             return rect.toAspectRatioDefault()
     }
 
+}
+
+private extension PlayScreen {
+    static func updateStoredWindowSize(from rect: CGRect, isReversed: Bool) {
+        guard rect.width.isFinite, rect.height.isFinite, rect.width > 0, rect.height > 0 else { return }
+        let width = isReversed ? rect.height : rect.width
+        let height = isReversed ? rect.width : rect.height
+        PlaySettings.shared.persistWindowSize(width: width, height: height, isInverted: isInvertFixEnabled)
+    }
 }
 
 extension CGFloat {

--- a/PlayTools/PlaySettings.swift
+++ b/PlayTools/PlaySettings.swift
@@ -1,3 +1,4 @@
+import Dispatch
 import Foundation
 import UIKit
 
@@ -9,6 +10,10 @@ let settings = PlaySettings.shared
     let bundleIdentifier = Bundle.main.infoDictionary?["CFBundleIdentifier"] as? String ?? ""
     let settingsUrl: URL
     var settingsData: AppSettingsData
+    private var cachedWindowSizeWidth: CGFloat
+    private var cachedWindowSizeHeight: CGFloat
+    private let windowSizeUpdateTolerance: CGFloat = 0.5
+    private var pendingWindowSizeSave: DispatchWorkItem?
 
     override init() {
         settingsUrl = URL(fileURLWithPath: "/Users/\(NSUserName())/Library/Containers/io.playcover.PlayCover")
@@ -21,6 +26,9 @@ let settings = PlaySettings.shared
             settingsData = AppSettingsData()
             print("[PlayTools] PlaySettings decode failed.\n%@")
         }
+        cachedWindowSizeWidth = CGFloat(settingsData.windowWidth)
+        cachedWindowSizeHeight = CGFloat(settingsData.windowHeight)
+        super.init()
     }
 
     lazy var discordActivity = settingsData.discordActivity
@@ -33,9 +41,23 @@ let settings = PlaySettings.shared
 
     @objc lazy var bypass = settingsData.bypass
 
-    @objc lazy var windowSizeHeight = CGFloat(settingsData.windowHeight)
+    @objc var windowSizeHeight: CGFloat {
+        get { cachedWindowSizeHeight }
+        set {
+            if updateWindowHeightIfNeeded(newValue) {
+                scheduleWindowSizeSave()
+            }
+        }
+    }
 
-    @objc lazy var windowSizeWidth = CGFloat(settingsData.windowWidth)
+    @objc var windowSizeWidth: CGFloat {
+        get { cachedWindowSizeWidth }
+        set {
+            if updateWindowWidthIfNeeded(newValue) {
+                scheduleWindowSizeSave()
+            }
+        }
+    }
 
     @objc lazy var inverseScreenValues = settingsData.inverseScreenValues
 
@@ -85,6 +107,57 @@ let settings = PlaySettings.shared
     @objc lazy var hideTitleBar = settingsData.hideTitleBar
 
     @objc lazy var checkMicPermissionSync = settingsData.checkMicPermissionSync
+
+    func persistWindowSize(width: CGFloat, height: CGFloat, isInverted: Bool) {
+        let targetWidth = isInverted ? height : width
+        let targetHeight = isInverted ? width : height
+
+        let didUpdateWidth = updateWindowWidthIfNeeded(targetWidth)
+        let didUpdateHeight = updateWindowHeightIfNeeded(targetHeight)
+
+        if didUpdateWidth || didUpdateHeight {
+            scheduleWindowSizeSave()
+        }
+    }
+
+    private func updateWindowWidthIfNeeded(_ value: CGFloat) -> Bool {
+        let normalized = normalizedWindowValue(value)
+        guard abs(cachedWindowSizeWidth - normalized) > windowSizeUpdateTolerance else { return false }
+        cachedWindowSizeWidth = normalized
+        settingsData.windowWidth = Int(normalized)
+        return true
+    }
+
+    private func updateWindowHeightIfNeeded(_ value: CGFloat) -> Bool {
+        let normalized = normalizedWindowValue(value)
+        guard abs(cachedWindowSizeHeight - normalized) > windowSizeUpdateTolerance else { return false }
+        cachedWindowSizeHeight = normalized
+        settingsData.windowHeight = Int(normalized)
+        return true
+    }
+
+    private func normalizedWindowValue(_ value: CGFloat) -> CGFloat {
+        let rounded = max(1, Int(round(value)))
+        return CGFloat(rounded)
+    }
+
+    private func scheduleWindowSizeSave() {
+        pendingWindowSizeSave?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.writeSettingsData()
+        }
+        pendingWindowSizeSave = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: workItem)
+    }
+
+    private func writeSettingsData() {
+        do {
+            let encoded = try PropertyListEncoder().encode(settingsData)
+            try encoded.write(to: settingsUrl)
+        } catch {
+            print("[PlayTools] PlaySettings save failed: \(error)")
+        }
+    }
 }
 
 struct AppSettingsData: Codable {


### PR DESCRIPTION
## Summary
- update PlayScreen hooks to capture runtime window bounds and push them back into PlaySettings so manual resizes stick
- extend PlaySettings to cache window dimensions, normalize updates, and persist them asynchronously to the existing plist

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca246261708323bcc6cd6b49716238